### PR TITLE
Add an option for setting a prefix on events

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -17,8 +17,10 @@ var get = require('obj-case');
 var track = exports.track = function(track){
   var event = exports.clean(track.event());
   var opts = track.options();
+  var prefix = this.settings && this.settings.prefix;
+  if (prefix && !endswith(prefix, '.')) prefix = prefix + '.';
   return {
-    name: event,
+    name: (prefix || '') + event,
     value: track.value() == null ? 1 : track.value(),
     measure_time: time(track.timestamp()),
     source: track.options(this.name).source
@@ -55,3 +57,17 @@ exports.clean = function(event){
     .replace(/[^a-z0-9._-]/gi, '-')
     .substring(0, 255);
 };
+
+/**
+ * Test whether a string ends with the suffix
+ *
+ * @param {String} str
+ * @param {String} suffix
+ * @return {String}
+ * @api private
+ */
+
+function endswith(str, suffix){
+  str = str.toLowerCase();
+  return str.substr(str.length - suffix.length) === suffix;
+}

--- a/test/fixtures/page-basic.json
+++ b/test/fixtures/page-basic.json
@@ -12,7 +12,7 @@
     }
   },
   "output": {
-    "name": "Loaded-a-Page",
+    "name": "test.Loaded-a-Page",
     "measure_time": 1388534400,
     "source": "src",
     "value": 2

--- a/test/fixtures/page-name.json
+++ b/test/fixtures/page-name.json
@@ -13,7 +13,7 @@
     }
   },
   "output": {
-    "name": "Viewed-Home-Page",
+    "name": "test.Viewed-Home-Page",
     "measure_time": 1388534400,
     "source": "src",
     "value": 2

--- a/test/fixtures/track-basic.json
+++ b/test/fixtures/track-basic.json
@@ -13,7 +13,7 @@
     }
   },
   "output": {
-    "name": "my-event",
+    "name": "test.my-event",
     "measure_time": 1388534400,
     "source": "src",
     "value": 2

--- a/test/fixtures/track-context-source.json
+++ b/test/fixtures/track-context-source.json
@@ -11,7 +11,7 @@
     }
   },
   "output": {
-    "name": "my-event",
+    "name": "test.my-event",
     "measure_time": 1388534400,
     "source": "src",
     "value": 2

--- a/test/fixtures/track-fallback.json
+++ b/test/fixtures/track-fallback.json
@@ -5,7 +5,7 @@
     "timestamp": "2014"
   },
   "output": {
-    "name": "my-event",
+    "name": "test.my-event",
     "measure_time": 1388534400,
     "source": "my-event",
     "value": 1

--- a/test/fixtures/track-source.json
+++ b/test/fixtures/track-source.json
@@ -11,7 +11,7 @@
     }
   },
   "output": {
-    "name": "my-event",
+    "name": "test.my-event",
     "measure_time": 1388534400,
     "source": "src",
     "value": 2

--- a/test/index.js
+++ b/test/index.js
@@ -9,13 +9,19 @@ var assert = require('assert');
 var Librato = require('..');
 
 describe('Librato', function(){
-  var settings;
+  var settings, settings_without_prefix;
   var librato;
 
   beforeEach(function(){
     settings = {
       email: 'testing+librato@segment.io',
-      token: 'eb753e965bfb546525fa78bb2c9472e50c16aa573f993e953c6773ff16f4c676'
+      token: 'eb753e965bfb546525fa78bb2c9472e50c16aa573f993e953c6773ff16f4c676',
+      prefix: 'test.'
+    };
+    settings_without_prefix = {
+      email: 'testing+librato@segment.io',
+      token: 'eb753e965bfb546525fa78bb2c9472e50c16aa573f993e953c6773ff16f4c676',
+      prefix: undefined
     };
     librato = new Librato(settings);
     test = Test(librato, __dirname);
@@ -86,6 +92,23 @@ describe('Librato', function(){
         .track(track)
         .sends({
           gauges: [{
+            name: settings.prefix + event,
+            value: 1,
+            measure_time: time(track.timestamp()),
+            source: event
+          }]
+        })
+        .expects(200)
+        .end(done);
+    });
+
+    it('should track successfully without a prefix', function(done){
+      var event = librato.mapper.clean(track.event());
+      test
+        .set(settings_without_prefix)
+        .track(track)
+        .sends({
+          gauges: [{
             name: event,
             value: 1,
             measure_time: time(track.timestamp()),
@@ -125,6 +148,23 @@ describe('Librato', function(){
       var event = librato.mapper.clean(page.track(page.fullName()).event());
       test
         .set(settings)
+        .page(page)
+        .sends({
+          gauges: [{
+            name: settings.prefix + event,
+            value: 1,
+            measure_time: time(page.timestamp()),
+            source: event
+          }]
+        })
+        .expects(200)
+        .end(done);
+    });
+
+    it('should send page successfully without a prefix', function(done){
+      var event = librato.mapper.clean(page.track(page.fullName()).event());
+      test
+        .set(settings_without_prefix)
         .page(page)
         .sends({
           gauges: [{


### PR DESCRIPTION
Just getting bare events from Segment into your Librato stats is fairly hard to manage, so this allows you to configure a prefix for your event names in Segment. This will allow you to send `segment.test.signed_up` and `segment.prod.signed_up` rather than just `signed_up` in every environment.

Note: I do not fully understand how settings come in from the actual system, so my tests assume certain things that may not be the case. If there's something you see as odd in here, let me know and I'll fix it up.